### PR TITLE
Add CLI session resumption; remove shareSession toggle

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+This repository contains an n8n community node implemented in TypeScript (`strict` mode) for the GitHub Copilot SDK.
+
+When making changes:
+- Keep edits minimal and scoped to the requested behavior.
+- Preserve n8n node patterns (`NodeOperationError`, `pairedItem`, credential test + `execute` parity).
+- Ensure Copilot client/session lifecycle safety (`start`/`stop`, `createSession`/`resumeSession`, `disconnect` in `finally`).
+- Prefer existing npm scripts for verification (`npm run lint`, `npm run build`).
+- Do not introduce new dependencies unless absolutely necessary.

--- a/nodes/CopilotAgent/CopilotAgent.node.ts
+++ b/nodes/CopilotAgent/CopilotAgent.node.ts
@@ -31,6 +31,8 @@ interface CopilotClientExtended {
 	listModels?: () => Promise<CopilotModel[]>;
 }
 
+type CopilotSession = Awaited<ReturnType<CopilotClient['createSession']>>;
+
 function buildCopilotClientConfig(credentials: CredentialsWithAuth): CopilotClientConfig {
 	const config: CopilotClientConfig = {};
 
@@ -97,7 +99,7 @@ async function executeWithResumedSession(
 ): Promise<INodeExecutionData[]> {
 	const returnData: INodeExecutionData[] = [];
 
-	let session;
+	let session: CopilotSession;
 	try {
 		session = await client.resumeSession(resumeSessionId, { onPermissionRequest: approveAll });
 	} catch {
@@ -164,7 +166,7 @@ async function executeIsolatedSession(
 			continue;
 		}
 
-		let session;
+		let session: CopilotSession | undefined;
 		try {
 			session = await client.createSession({
 				model: model || 'gpt-5',
@@ -246,7 +248,6 @@ export class CopilotAgent implements INodeType {
 				name: 'resumeSessionId',
 				type: 'string',
 				default: '',
-				required: false,
 				description:
 					'Optional session ID from a previous run. When provided, the node attempts to resume that session and reuses it for all items in the batch. If the session is not found or resumption fails, a new session is started automatically.',
 			},
@@ -343,21 +344,21 @@ export class CopilotAgent implements INodeType {
 		const client = new CopilotClient(config);
 
 		try {
-			await client.start();
-		} catch (error) {
-			if (credentials.cliUrl) {
+			try {
+				await client.start();
+			} catch (error) {
+				if (credentials.cliUrl) {
+					throw new NodeOperationError(
+						this.getNode(),
+						`Failed to connect to remote CLI server at ${credentials.cliUrl}: ${(error as Error).message}. When a CLI Server URL is configured, no subprocess fallback is attempted.`,
+					);
+				}
 				throw new NodeOperationError(
 					this.getNode(),
-					'Failed to connect to remote CLI server. When a CLI Server URL is configured, no subprocess fallback is attempted.',
+					`Failed to start local CLI subprocess: ${(error as Error).message}`,
 				);
 			}
-			throw new NodeOperationError(
-				this.getNode(),
-				`Failed to start local CLI subprocess: ${(error as Error).message}`,
-			);
-		}
 
-		try {
 			const returnData = resumeSessionId
 				? await executeWithResumedSession(this, client, items, model, resumeSessionId)
 				: await executeIsolatedSession(this, client, items, model);

--- a/nodes/CopilotAgent/CopilotAgent.node.ts
+++ b/nodes/CopilotAgent/CopilotAgent.node.ts
@@ -88,18 +88,21 @@ async function getModelOptionsImpl(this: ILoadOptionsFunctions) {
 	];
 }
 
-async function executeSharedSession(
+async function executeWithResumedSession(
 	context: IExecuteFunctions,
 	client: CopilotClient,
 	items: INodeExecutionData[],
 	model: string,
+	resumeSessionId: string,
 ): Promise<INodeExecutionData[]> {
 	const returnData: INodeExecutionData[] = [];
 
-	const session = await client.createSession({
-		model: model || 'gpt-5',
-		onPermissionRequest: approveAll,
-	});
+	let session;
+	try {
+		session = await client.resumeSession(resumeSessionId, { onPermissionRequest: approveAll });
+	} catch {
+		session = await client.createSession({ model: model || 'gpt-5', onPermissionRequest: approveAll });
+	}
 
 	try {
 		for (let i = 0; i < items.length; i++) {
@@ -239,12 +242,13 @@ export class CopilotAgent implements INodeType {
 				description: 'Message to send to Copilot',
 			},
 			{
-				displayName: 'Share Session Across Items',
-				name: 'shareSession',
-				type: 'boolean',
-				default: false,
+				displayName: 'Resume Session ID',
+				name: 'resumeSessionId',
+				type: 'string',
+				default: '',
+				required: false,
 				description:
-					'Whether to share a single session across all items. When disabled (default), each item gets its own isolated session for predictable, independent results. When enabled, all items share one session and context carries forward across the batch.',
+					'Optional session ID from a previous run. When provided, the node attempts to resume that session and reuses it for all items in the batch. If the session is not found or resumption fails, a new session is started automatically.',
 			},
 		],
 		usableAsTool: true,
@@ -313,11 +317,11 @@ export class CopilotAgent implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		let credentials;
+		let credentials: CredentialsWithAuth;
 		let config: CopilotClientConfig;
 
 		try {
-			credentials = await this.getCredentials('copilotAgentApi');
+			credentials = (await this.getCredentials('copilotAgentApi')) as CredentialsWithAuth;
 		} catch (error) {
 			throw new NodeOperationError(
 				this.getNode(),
@@ -326,7 +330,7 @@ export class CopilotAgent implements INodeType {
 		}
 
 		try {
-			config = buildCopilotClientConfig(credentials as CredentialsWithAuth);
+			config = buildCopilotClientConfig(credentials);
 		} catch (error) {
 			throw new NodeOperationError(
 				this.getNode(),
@@ -335,14 +339,27 @@ export class CopilotAgent implements INodeType {
 		}
 
 		const model = this.getNodeParameter('model', 0) as string;
-		const shareSession = this.getNodeParameter('shareSession', 0, false) as boolean;
+		const resumeSessionId = this.getNodeParameter('resumeSessionId', 0, '') as string;
 		const client = new CopilotClient(config);
 
 		try {
 			await client.start();
+		} catch (error) {
+			if (credentials.cliUrl) {
+				throw new NodeOperationError(
+					this.getNode(),
+					'Failed to connect to remote CLI server. When a CLI Server URL is configured, no subprocess fallback is attempted.',
+				);
+			}
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to start local CLI subprocess: ${(error as Error).message}`,
+			);
+		}
 
-			const returnData = shareSession
-				? await executeSharedSession(this, client, items, model)
+		try {
+			const returnData = resumeSessionId
+				? await executeWithResumedSession(this, client, items, model, resumeSessionId)
 				: await executeIsolatedSession(this, client, items, model);
 
 			return [returnData];

--- a/nodes/CopilotAgent/CopilotAgent.node.ts
+++ b/nodes/CopilotAgent/CopilotAgent.node.ts
@@ -99,12 +99,13 @@ async function executeWithResumedSession(
 ): Promise<INodeExecutionData[]> {
 	const returnData: INodeExecutionData[] = [];
 
-	let session: CopilotSession;
-	try {
-		session = await client.resumeSession(resumeSessionId, { onPermissionRequest: approveAll });
-	} catch {
-		session = await client.createSession({ model: model || 'gpt-5', onPermissionRequest: approveAll });
-	}
+	const session: CopilotSession = await (async () => {
+		try {
+			return await client.resumeSession(resumeSessionId, { onPermissionRequest: approveAll });
+		} catch {
+			return await client.createSession({ model: model || 'gpt-5', onPermissionRequest: approveAll });
+		}
+	})();
 
 	try {
 		for (let i = 0; i < items.length; i++) {


### PR DESCRIPTION
- Replace `executeSharedSession` with `executeWithResumedSession`: tries
  `client.resumeSession(id)` first, falls back to `createSession` if the
  session is not found, then reuses that one session for all batch items
- Add optional `resumeSessionId` node property (string, always visible);
  replaces the removed `shareSession` boolean toggle
- Enforce hard-fail in `execute()` when `cliUrl` is set and `client.start()`
  fails — no subprocess fallback is attempted

https://claude.ai/code/session_01Y2HCkuFKDWwy8GEnzYFZ59